### PR TITLE
Fix typo.

### DIFF
--- a/tools/bvgraph2smat/bvgraph2smat.cc
+++ b/tools/bvgraph2smat/bvgraph2smat.cc
@@ -82,7 +82,7 @@ bool write_badj_format(bvgraph *g, bvgraph_iterator *git, const char *outname) {
     fwrite(&n, sizeof(int64_t), 1, f);
     fwrite(&m, sizeof(int64_t), 1, f);
     
-    if (m > 4294967296)
+    if (n > 4294967296)
     {
         int64_t *links; uint64_t i, d;
         for (; 

--- a/tools/bvgraph2smat/bvgraph2smat.cc
+++ b/tools/bvgraph2smat/bvgraph2smat.cc
@@ -82,7 +82,7 @@ bool write_badj_format(bvgraph *g, bvgraph_iterator *git, const char *outname) {
     fwrite(&n, sizeof(int64_t), 1, f);
     fwrite(&m, sizeof(int64_t), 1, f);
     
-    if (n > 4294967296)
+    if (n > 4294967294)
     {
         int64_t *links; uint64_t i, d;
         for (; 


### PR DESCRIPTION
This should convert to BADJ graphs with up to 2^32 nodes, not 2^32 edges.
